### PR TITLE
Fix deeplink test sync issues

### DIFF
--- a/cobalt/black_box_tests/tests/deep_links.py
+++ b/cobalt/black_box_tests/tests/deep_links.py
@@ -78,6 +78,14 @@ class JavascriptRequestDetector(MakeRequestHandlerClass(_SERVER_ROOT_PATH)):
 class DeepLink(black_box_tests.BlackBoxTestCase):
   """Tests firing deep links before web module is loaded."""
 
+  def setUp(self):
+    _script_loading_signal.clear()
+    super().setUp()
+
+  def tearDown(self):
+    _script_loading_signal.clear()
+    super().tearDown()
+  
   def _load_page(self, webdriver, url):
     """Instructs webdriver to navigate to url."""
     try:

--- a/cobalt/black_box_tests/tests/deep_links.py
+++ b/cobalt/black_box_tests/tests/deep_links.py
@@ -85,7 +85,7 @@ class DeepLink(black_box_tests.BlackBoxTestCase):
   def tearDown(self):
     _script_loading_signal.clear()
     super().tearDown()
-  
+
   def _load_page(self, webdriver, url):
     """Instructs webdriver to navigate to url."""
     try:


### PR DESCRIPTION
Reset the synchronization event for every test invocation. It would be better to not declare it at module level at all and move it to test class scope, but this should keep the fix simpler.

b/232938389